### PR TITLE
Fix TransactWriteItems string

### DIFF
--- a/dax/internal/client/single.go
+++ b/dax/internal/client/single.go
@@ -381,7 +381,7 @@ func (client *SingleDaxClient) TransactWriteItemsWithOptions(ctx context.Context
 		output, err = decodeTransactWriteItemsOutput(ctx, reader, input, client.keySchema, client.attrListIdToNames, output)
 		return err
 	}
-	if err := client.executeWithRetries(ctx, OpBatchWriteItem, opt, encoder, decoder); err != nil {
+	if err := client.executeWithRetries(ctx, OpTransactWriteItems, opt, encoder, decoder); err != nil {
 		if failure, ok := err.(*daxTransactionCanceledFailure); ok {
 			var cancellationReasons []types.CancellationReason
 			if cancellationReasons, err = decodeTransactionCancellationReasons(ctx, failure, extractedKeys, client.attrListIdToNames); err != nil {


### PR DESCRIPTION
Fixes the string passed to `executeWithRetries()` in the `TransactWriteItems` request. Errors in the requests were reporting the wrong API name.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
